### PR TITLE
fix invalid boolean conversion

### DIFF
--- a/lib/s3ranger/sync.rb
+++ b/lib/s3ranger/sync.rb
@@ -275,7 +275,7 @@ module S3Ranger
 
     def read_tree_remote location
       dir = location.path
-      dir += '/' if not dir.empty? or dir.end_with?('/')
+      dir += '/' if not dir.empty? and not dir.end_with?('/')
       @args.s3.buckets[location.bucket].objects.with_prefix(dir || "").to_a.collect {|obj|
         Node.new location.path, obj.key, obj.content_length
       }


### PR DESCRIPTION
```
dir += '/' if not (dir.empty? or dir.end_with? '/')
is not the same as
dir += '/' if not dir.empty? or dir.end_with?('/')
```

530dac22c2c4bf7d3464fe7e0859a667ae3653f2

@clarete
