### PR TITLE
remove trailing comma

### DIFF
--- a/lib/s3sync/cli.rb
+++ b/lib/s3sync/cli.rb
@@ -440,7 +440,7 @@ END
           # Connecting to amazon
           s3 = AWS::S3.new(
             :access_key_id => conf[:AWS_ACCESS_KEY_ID],
-            :secret_access_key => conf[:AWS_SECRET_ACCESS_KEY],
+            :secret_access_key => conf[:AWS_SECRET_ACCESS_KEY]
           )
 
           # From the command line


### PR DESCRIPTION
The trailing comma gave me an error when I tried to use `s3sync help sync`

```
/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/rubygems/custom_require.rb:31:in   
`gem_original_require': /Library/Ruby/Gems/1.8/gems/s3sync-2.0.0/bin/../lib/s3sync/cli.rb:444: syntax error,   
unexpected ')' (SyntaxError)
```
