### PR TITLE
Feature/net http handler error

### DIFF
--- a/lib/s3sync/sync.rb
+++ b/lib/s3sync/sync.rb
@@ -331,6 +331,7 @@ module S3Sync
     end
 
     def download_files destination, source, list
+      puts list
       list.each {|e|
         path = File.join destination.path, e.path
 
@@ -344,16 +345,23 @@ module S3Sync
           # Making sure this new file will have a safe shelter
           FileUtils.mkdir_p File.dirname(path)
 
-          # Downloading and saving the files
-          File.open(path, 'wb') do |file|
-            begin
-              obj.read do |chunk|
-                file.write chunk
+          # in some cases the s3 object will have a trailing '/' indicating
+          # a folder (this behavior noticed when the s3 folder is
+          # created by Transmit)
+          if path[-1] == '/'
+            FileUtils.mkdir_p path
+          else
+            # Downloading and saving the files
+            File.open(path, 'wb') do |file|
+              begin
+                obj.read do |chunk|
+                  file.write chunk
+                end
+              rescue AWS::Core::Http::NetHttpHandler::TruncatedBodyError => e
+                $stderr.puts "WARNING: (retryable) TruncatedBodyError occured, retrying in a second #{file.basename}"
+                sleep 1
+                retry
               end
-            rescue AWS::Core::Http::NetHttpHandler::TruncatedBodyError => e
-              $stderr.puts "WARNING: (retryable) TruncatedBodyError occured, retrying in a second #{file}"
-              sleep 1
-              retry
             end
           end
         end


### PR DESCRIPTION
For some large S3 downloads or if your internet connection is spotty, the get chunk can fail with the TruncatedBodyError. Based on the [code](https://github.com/aws/aws-sdk-ruby/blob/084f603f20/lib/aws/core/http/net_http_handler.rb) it seems to be retryable.
