### PR TITLE
Removed checks for ENV vars and let the AWS SDK figure how to authenticate

### DIFF
--- a/lib/s3sync/cli.rb
+++ b/lib/s3sync/cli.rb
@@ -438,10 +438,7 @@ END
         define_method :execute, lambda { |args|
 
           # Connecting to amazon
-          s3 = AWS::S3.new(
-            :access_key_id => conf[:AWS_ACCESS_KEY_ID],
-            :secret_access_key => conf[:AWS_SECRET_ACCESS_KEY]
-          )
+          s3 = AWS::S3.new
 
           # From the command line
           key, file = args

--- a/lib/s3sync/config.rb
+++ b/lib/s3sync/config.rb
@@ -86,10 +86,6 @@ module S3Sync
       # Checking which variables we have
       not_found = []
 
-      REQUIRED_VARS.each {|v|
-        not_found << v if self[v].nil?
-      }
-
       # Cleaning possibly empty env var from CONFIG_PATH
       paths = (paths_checked || CONFIG_PATHS).select {|e| !e.empty?}
       raise NoConfigFound.new(not_found, paths) if not_found.count > 0


### PR DESCRIPTION
The AWS SDK is pretty smart about using a few different ways to configure itself.  By default, it will use the same ENV vars that you look for, but will also use IAM roles if they are enabled. That means that this PR should fix https://github.com/clarete/s3sync/issues/15 also.

For more information about how the AWS SDK looks for credentials, please see this:
http://docs.aws.amazon.com/AWSSdkDocsRuby/latest/DeveloperGuide/ruby-dg-roles.html
