### PR TITLE
Make "s3sync sync foo bucket:bar" idempotent

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
 require "bundler/setup"
 require "bundler/gem_tasks"
 require "bump/tasks"
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)

--- a/lib/s3sync/sync.rb
+++ b/lib/s3sync/sync.rb
@@ -314,6 +314,9 @@ module S3Sync
     def read_trees source, destination
       if source.local?
         source_tree = LocalDirectory.new(source.path).list_files
+        source_tree = source_tree.reduce({}) do |a,(_,v)|
+          key = S3Sync.safe_join([destination.path, v.path]); a[key] = v; a
+        end
         destination_tree = read_tree_remote destination
       else
         source_tree = read_tree_remote source


### PR DESCRIPTION
Previously, running `s3sync foo bucket:bar` twice in a row, regardless of
whether the contents of `foo` had changed, would result in the second run
uploading and then deleting the same files, leaving you with an empty S3
bucker:folder.

The other direction, `s3sync sync bucket:bar foo`, remains idempotent, if a
little wonky.