### PR TITLE
Fix file exsitence check key to use relative path from dir of S3.

### DIFF
--- a/lib/s3sync/sync.rb
+++ b/lib/s3sync/sync.rb
@@ -306,7 +306,9 @@ module S3Sync
         # etag comes back with quotes (obj.etag.inspcet # => "\"abc...def\""
         small_comparator = lambda { obj.etag[/[a-z0-9]+/] }
         node = Node.new(location.path, obj.key, obj.content_length, small_comparator)
-        nodes[node.path] = node
+        # The key is relative path from dir.
+        key = node.path[(dir || "").length,node.path.length - 1]
+        nodes[key] = node
       end
       return nodes
     end


### PR DESCRIPTION
s3sync should use relative path from dir to check file existence both in local and S3, but not now.

Phenomenon.
On second time I try to sync my local dir to s3, s3sync uploads all files in local and deletes all files which existed in s3 before upload.  

This pull request may fix same bug reported by [spiffxp's pull request](https://github.com/clarete/s3sync/pull/31).
I wonder how such critical bug remains.
