### PR TITLE
cmdparse version 2.0.5

### DIFF
--- a/s3sync.gemspec
+++ b/s3sync.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   # Library requirements
   spec.add_dependency "aws-sdk"
-  spec.add_dependency "cmdparse"
+  spec.add_dependency "cmdparse", '2.0.5'
 
   # Development requirements
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
cmdparse changed after 2.0.5 to have a different amount of arguments on initialize.  The below error is with cmdparse 3.0.1.

```
cmdparse-3.0.1/lib/cmdparse.rb:796:in `initialize': wrong number of arguments (1 for 0) (ArgumentError)
```

... so it needs to be downgraded to 2.0.5 in the app's Gemfile --or-- this pull request can be accepted --or-- somebody could take more time to adopt the new cmdparse (I don't have time right now).