### PR TITLE
Lock aws-sdk & cmdparse versions

### DIFF
--- a/s3sync.gemspec
+++ b/s3sync.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
   # Library requirements
-  spec.add_dependency "aws-sdk"
-  spec.add_dependency "cmdparse"
+  spec.add_dependency "aws-sdk", "< 2.0"
+  spec.add_dependency "cmdparse", "~> 2.0"
 
   # Development requirements
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
fixes #34, the problem is that aws-sdk & cmdparse versions isn't locked in gemspec, and now there is a new major version of [aws-sdk gem](http://ruby.awsblog.com/post/TxFKSK2QJE6RPZ/Upcoming-Stable-Release-of-AWS-SDK-for-Ruby-Version-2)