### PR TITLE
Update s3sync.gemspec

### DIFF
--- a/s3sync.gemspec
+++ b/s3sync.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
   # Library requirements
-  spec.add_dependency "aws-sdk", "~> 2.3.0"
+  spec.add_dependency "aws-sdk", "~> 2.3"
   spec.add_dependency "cmdparse", "~> 3.0"
 
   # Development requirements


### PR DESCRIPTION
The patch-level semantic versioning isn't necessary here; AWS's API is stable through v2.